### PR TITLE
rename partitionfinder to PartitionFinder (which seems to be the official software name) & fix homepage

### DIFF
--- a/easybuild/easyconfigs/p/PartitionFinder/PartitionFinder-2.1.1-intel-2019b-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/p/PartitionFinder/PartitionFinder-2.1.1-intel-2019b-Python-2.7.16.eb
@@ -3,11 +3,11 @@
 
 easyblock = 'Tarball'
 
-name = 'partitionfinder'
+name = 'PartitionFinder'
 version = '2.1.1'
 versionsuffix = '-Python-%(pyver)s'
 
-homepage = 'https://github.com/brettc/partitionfinder/releases/tag/v2.1.1'
+homepage = 'https://www.robertlanfear.com/partitionfinder'
 description = """PartitionFinder 2 is a Python program for simultaneously
 choosing partitioning schemes and models of molecular evolution for phylogenetic
 analyses of DNA, protein, and morphological data. You can PartitionFinder 2


### PR DESCRIPTION
for https://github.com/easybuilders/easybuild-easyconfigs/pull/9983

@Darkless012 Just a tiny change to your PR, since we prefer to stick to the official software name (and I noticed the homepage was a bit off too).

The easyconfig still works as expected with this change.