### PR TITLE
use system toolchain to build ccache, but include GCC/9.3.0 as build dependency to avoid relying on system compiler + use release source tarball

### DIFF
--- a/easybuild/easyconfigs/c/ccache/ccache-3.7.11.eb
+++ b/easybuild/easyconfigs/c/ccache/ccache-3.7.11.eb
@@ -15,22 +15,21 @@ homepage = 'https://ccache.dev/'
 description = """Ccache (or “ccache”) is a compiler cache. It speeds up recompilation by 
 caching previous compilations and detecting when the same compilation is being done again"""
 
-toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
-toolchainopts = {'static': True}
+toolchain = SYSTEM
 
-source_urls = [GITHUB_SOURCE]
-sources = ['v%(version)s.tar.gz']
-checksums = ['7fe84027211465742cf09a2733347c5a9273d90d48ee58f171783d917d13ded2']
+source_urls = ['https://github.com/ccache/ccache/releases/download/v%(version)s/']
+sources = [SOURCE_TAR_GZ]
+checksums = ['34309a59d4b6b6b33756366aa9d3144a4655587be9f914476b4c0e2d36365f01']
 
 osdependencies = [('glibc-static', 'libc6-dev')]
 
+local_gccver = '9.3.0'
 builddependencies = [
-    ('binutils', '2.34'),
-    ('Autotools', '20180311'),
-    ('zlib', '1.2.11'),
+    ('GCC', local_gccver),
+    ('Autotools', '20180311', '', ('GCCcore', local_gccver)),
+    ('zlib', '1.2.11', '', ('GCCcore', local_gccver)),
 ]
 
-preconfigopts = "./autogen.sh && "
 buildopts = 'LDFLAGS="-static"'
 
 sanity_check_paths = {


### PR DESCRIPTION
…

@Darkless012 for https://github.com/easybuilders/easybuild-easyconfigs/pull/11122